### PR TITLE
CONTENT: Juz 30 / Juz Amma supporting cluster articles (Tier 3)

### DIFF
--- a/content/blog/2026-04-28-surat-pendek-untuk-dihafal-dan-sholat/index.md
+++ b/content/blog/2026-04-28-surat-pendek-untuk-dihafal-dan-sholat/index.md
@@ -1,0 +1,47 @@
+---
+title: Surat-surat Pendek untuk Dihafal Anak dan Dibaca saat Sholat
+description: Kumpulan surat pendek dalam Juz 30 yang mudah dihafal anak dan sering dibaca saat sholat, lengkap dengan arti dan jumlah ayatnya.
+date: '2026-04-28T23:59:59.121Z'
+---
+
+Surat-surat pendek di akhir [Juz 30](/2020-06-15-daftar-lengkap-surat-dalam-juz-amma-alquran-juz-30/) adalah pilihan terbaik untuk memulai perjalanan menghafal Al-Quran. Selain ayatnya yang singkat dan mudah diingat, surat-surat ini juga paling sering dibaca dalam sholat sehari-hari, sehingga sangat bermanfaat untuk dikuasai sejak dini, baik oleh anak-anak maupun pemula.
+
+Berikut ini adalah lima belas surat pendek pilihan beserta arti dan jumlah ayatnya. Teks Arab dan terjemahan lengkapnya bisa Anda baca langsung di [Baca-Quran.id](https://www.baca-quran.id/juz-amma/).
+
+## 15 Surat Pendek Pilihan dalam Juz 30
+
+| No. | Nama Surat | Arti Nama | Jumlah Ayat |
+| --- | ---------- | --------- | ----------- |
+| 100 | [Al-'Adiyat](https://www.baca-quran.id/surah/100/) | Kuda Perang Yang Berlari Kencang | 11 |
+| 101 | [Al-Qari'ah](https://www.baca-quran.id/surah/101/) | Hari Kiamat | 11 |
+| 102 | [At-Takasur](https://www.baca-quran.id/surah/102/) | Bermegah-Megahan | 8 |
+| 103 | [Al-'Asr](https://www.baca-quran.id/surah/103/) | Masa | 3 |
+| 104 | [Al-Humazah](https://www.baca-quran.id/surah/104/) | Pengumpat | 9 |
+| 105 | [Al-Fil](https://www.baca-quran.id/surah/105/) | Gajah | 5 |
+| 106 | [Quraisy](https://www.baca-quran.id/surah/106/) | Suku Quraisy | 4 |
+| 107 | [Al-Ma'un](https://www.baca-quran.id/surah/107/) | Barang Yang Berguna | 7 |
+| 108 | [Al-Kausar](https://www.baca-quran.id/surah/108/) | Nikmat Yang Banyak | 3 |
+| 109 | [Al-Kafirun](https://www.baca-quran.id/surah/109/) | Orang-Orang Kafir | 6 |
+| 110 | [An-Nasr](https://www.baca-quran.id/surah/110/) | Pertolongan | 3 |
+| 111 | [Al-Lahab](https://www.baca-quran.id/surah/111/) | Gejolak Api | 5 |
+| 112 | [Al-Ikhlas](https://www.baca-quran.id/surah/112/) | Memurnikan Keesaan Allah | 4 |
+| 113 | [Al-Falaq](https://www.baca-quran.id/surah/113/) | Waktu Subuh | 5 |
+| 114 | [An-Nas](https://www.baca-quran.id/surah/114/) | Manusia | 6 |
+
+Sepuluh surat terakhir dalam daftar di atas, yaitu mulai dari [Al-Fil](https://www.baca-quran.id/surah/105/) sampai [An-Nas](https://www.baca-quran.id/surah/114/), sering disebut sebagai sepuluh surat terakhir dalam Al-Quran dan menjadi favorit untuk dihafalkan lebih dulu.
+
+## Mengapa Memulai dari Surat Pendek?
+
+Memulai hafalan dari surat pendek memberikan banyak keuntungan. Ayatnya yang singkat membuat anak maupun pemula tidak mudah merasa terbebani, sehingga semangat menghafal tetap terjaga. Selain itu, surat-surat ini sangat akrab di telinga karena rutin dibaca dalam sholat, sehingga proses menghafal terasa lebih alami. Penguasaan surat pendek juga menjadi fondasi yang kokoh sebelum melangkah ke surat-surat yang lebih panjang.
+
+## Tips Menghafal Surat Pendek
+
+**Konsisten setiap hari.** Luangkan waktu lima sampai sepuluh menit setiap hari untuk mengulang, sebab konsistensi jauh lebih penting daripada banyaknya hafalan dalam sekali waktu.
+
+**Dengarkan murottal.** Memperdengarkan bacaan qari favorit akan membantu memperbaiki pelafalan sekaligus mempercepat hafalan, terutama bagi anak-anak.
+
+**Pahami artinya.** Mengetahui makna surat membuat hafalan lebih bermakna dan tidak mudah lupa.
+
+**Ulang dalam sholat.** Membaca surat yang sedang dihafal ketika sholat adalah cara terbaik untuk memantapkannya, sekaligus menambah kekhusyukan ibadah.
+
+Sebagai penutup, surat pendek adalah pintu masuk yang ramah menuju hafalan Al-Quran. Untuk melengkapi bacaan Anda, silakan simak pula artikel [Urutan Surat Pendek Untuk Taraweh](/2021-07-26-surat-pendek-untuk-taraweh/) dan [Arti dan Makna Nama Surat dalam Juz 30](/2026-05-04-arti-dan-makna-nama-surat-juz-30/). Anda juga bisa membaca dan mendengarkan seluruh surat secara lengkap di [Baca-Quran.id](https://www.baca-quran.id/).

--- a/content/blog/2026-05-01-juz-amma-arab-saja-tanpa-terjemahan/index.md
+++ b/content/blog/2026-05-01-juz-amma-arab-saja-tanpa-terjemahan/index.md
@@ -1,0 +1,63 @@
+---
+title: Juz Amma Arab Saja, Membaca Juz 30 Tanpa Terjemahan
+description: Panduan membaca Juz Amma atau Juz 30 dalam teks Arab saja tanpa terjemahan, cocok untuk melatih kelancaran membaca dan memperkuat hafalan.
+date: '2026-05-01T23:59:59.121Z'
+---
+
+Sebagian dari kita lebih nyaman membaca Juz Amma dalam teks Arab saja, tanpa tulisan latin maupun terjemahan. Cara ini banyak dipilih untuk melatih kelancaran membaca, memperkuat hafalan, sekaligus melatih kemandirian dalam mengenali huruf dan harakat secara langsung.
+
+Artikel ini akan menjelaskan manfaat membaca [Juz 30](/2020-06-15-daftar-lengkap-surat-dalam-juz-amma-alquran-juz-30/) dalam format Arab saja, sekaligus menunjukkan cara membacanya dengan mudah melalui [Baca-Quran.id](https://www.baca-quran.id/juz-amma/).
+
+## Mengapa Membaca Juz Amma dalam Arab Saja?
+
+Membaca teks Arab tanpa terjemahan memiliki sejumlah manfaat, di antaranya:
+
+**Melatih kelancaran membaca.** Tanpa bergantung pada tulisan latin, mata dan lisan kita terbiasa langsung dengan huruf hijaiah, sehingga kemampuan membaca semakin terasah.
+
+**Memperkuat hafalan.** Bagi yang sedang menghafal, membaca Arab saja membantu mengingat letak ayat dan urutannya tanpa terganggu oleh teks tambahan.
+
+**Menjaga kekhusyukan.** Tampilan yang bersih dan fokus pada ayat membuat hati lebih tenang dan mudah meresapi bacaan.
+
+**Mempersiapkan bacaan sholat.** Surat-surat dalam Juz Amma sering dibaca saat sholat, sehingga membiasakan membaca teks Arabnya akan sangat bermanfaat.
+
+## Cara Membaca Juz Amma Arab Saja di Baca-Quran.id
+
+Anda bisa membaca seluruh surat dalam Juz 30 secara online dengan langkah sederhana berikut:
+
+Kunjungi halaman [Juz Amma di Baca-Quran.id](https://www.baca-quran.id/juz-amma/), lalu pilih surat yang ingin Anda baca. Setiap surat menampilkan teks Arab yang jelas dan mudah dibaca di layar ponsel.
+
+Bila Anda ingin tampilan yang lebih fokus pada teks Arab, silakan sesuaikan preferensi tampilan melalui halaman [Setelan](https://www.baca-quran.id/settings/). Dengan begitu, pengalaman membaca dapat disesuaikan dengan kebutuhan Anda.
+
+## Contoh Teks Arab Surat Pendek
+
+Sebagai gambaran, berikut dua surat pendek yang sangat sering dibaca, ditampilkan dalam teks Arab.
+
+### [Surat Al-Ikhlas](https://www.baca-quran.id/surah/112/)
+
+بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ
+
+قُلْ هُوَ اللّٰهُ اَحَدٌ
+
+اَللّٰهُ الصَّمَدُ
+
+لَمْ يَلِدْ وَلَمْ يُوْلَدْ
+
+وَلَمْ يَكُنْ لَّهٗ كُفُوًا اَحَدٌ
+
+### [Surat An-Nas](https://www.baca-quran.id/surah/114/)
+
+بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ
+
+قُلْ اَعُوْذُ بِرَبِّ النَّاسِ
+
+مَلِكِ النَّاسِ
+
+اِلٰهِ النَّاسِ
+
+مِنْ شَرِّ الْوَسْوَاسِ الْخَنَّاسِ
+
+الَّذِيْ يُوَسْوِسُ فِيْ صُدُوْرِ النَّاسِ
+
+مِنَ الْجِنَّةِ وَالنَّاسِ
+
+Sebagai penutup, membaca Juz Amma dalam teks Arab saja adalah cara yang baik untuk melatih kemandirian dan memperkuat hafalan. Untuk membaca seluruh surat secara lengkap beserta teks Arabnya, silakan kunjungi halaman [Juz Amma di Baca-Quran.id](https://www.baca-quran.id/juz-amma/). Anda juga bisa menyimak artikel [Arti dan Makna Nama Surat dalam Juz 30](/2026-05-04-arti-dan-makna-nama-surat-juz-30/) untuk memahami kandungan setiap suratnya.

--- a/content/blog/2026-05-04-arti-dan-makna-nama-surat-juz-30/index.md
+++ b/content/blog/2026-05-04-arti-dan-makna-nama-surat-juz-30/index.md
@@ -1,0 +1,73 @@
+---
+title: Arti dan Makna Nama Surat dalam Juz 30 (Juz Amma)
+description: Daftar arti nama surat dalam Juz 30 beserta jumlah ayat dan makna pokok kandungannya, mulai dari An-Naba' sampai An-Nas.
+date: '2026-05-04T23:59:59.121Z'
+---
+
+Setiap surat dalam Al-Quran memiliki nama yang sarat makna, dan tidak sedikit di antaranya yang diambil dari kata atau peristiwa penting di dalam surat tersebut. Memahami arti nama serta pokok kandungan sebuah surat akan membuat bacaan kita terasa lebih hidup, sekaligus memudahkan dalam menghafal.
+
+[Juz 30](/2020-06-15-daftar-lengkap-surat-dalam-juz-amma-alquran-juz-30/), atau yang akrab disebut Juz Amma, terdiri dari 37 surat. Berikut ini adalah daftar arti nama dan jumlah ayat dari seluruh suratnya, dilanjutkan dengan penjelasan singkat tentang tema utamanya. Teks Arab dan terjemahan lengkap setiap surat bisa Anda baca langsung di [Baca-Quran.id](https://www.baca-quran.id/juz-amma/).
+
+## Tabel Arti Nama Surat Juz 30
+
+| No. | Nama Surat | Arti Nama | Jumlah Ayat |
+| --- | ---------- | --------- | ----------- |
+| 78 | [An-Naba'](https://www.baca-quran.id/surah/78/) | Berita Besar | 40 |
+| 79 | [An-Nazi'at](https://www.baca-quran.id/surah/79/) | Malaikat Yang Mencabut | 46 |
+| 80 | ['Abasa](https://www.baca-quran.id/surah/80/) | Bermuka Masam | 42 |
+| 81 | [At-Takwir](https://www.baca-quran.id/surah/81/) | Penggulungan | 29 |
+| 82 | [Al-Infitar](https://www.baca-quran.id/surah/82/) | Terbelah | 19 |
+| 83 | [Al-Mutaffifin](https://www.baca-quran.id/surah/83/) | Orang-Orang Yang Curang | 36 |
+| 84 | [Al-Insyiqaq](https://www.baca-quran.id/surah/84/) | Terbelah | 25 |
+| 85 | [Al-Buruj](https://www.baca-quran.id/surah/85/) | Gugusan Bintang | 22 |
+| 86 | [At-Tariq](https://www.baca-quran.id/surah/86/) | Yang Datang di Malam Hari | 17 |
+| 87 | [Al-A'la](https://www.baca-quran.id/surah/87/) | Yang Maha Tinggi | 19 |
+| 88 | [Al-Gasyiyah](https://www.baca-quran.id/surah/88/) | Hari Pembalasan | 26 |
+| 89 | [Al-Fajr](https://www.baca-quran.id/surah/89/) | Fajar | 30 |
+| 90 | [Al-Balad](https://www.baca-quran.id/surah/90/) | Negeri | 20 |
+| 91 | [Asy-Syams](https://www.baca-quran.id/surah/91/) | Matahari | 15 |
+| 92 | [Al-Lail](https://www.baca-quran.id/surah/92/) | Malam | 21 |
+| 93 | [Ad-Duha](https://www.baca-quran.id/surah/93/) | Waktu Duha | 11 |
+| 94 | [Asy-Syarh](https://www.baca-quran.id/surah/94/) | Melapangkan | 8 |
+| 95 | [At-Tin](https://www.baca-quran.id/surah/95/) | Buah Tin | 8 |
+| 96 | [Al-'Alaq](https://www.baca-quran.id/surah/96/) | Segumpal Darah | 19 |
+| 97 | [Al-Qadr](https://www.baca-quran.id/surah/97/) | Kemuliaan | 5 |
+| 98 | [Al-Bayyinah](https://www.baca-quran.id/surah/98/) | Bukti Nyata | 8 |
+| 99 | [Az-Zalzalah](https://www.baca-quran.id/surah/99/) | Kegoncangan | 8 |
+| 100 | [Al-'Adiyat](https://www.baca-quran.id/surah/100/) | Kuda Perang Yang Berlari Kencang | 11 |
+| 101 | [Al-Qari'ah](https://www.baca-quran.id/surah/101/) | Hari Kiamat | 11 |
+| 102 | [At-Takasur](https://www.baca-quran.id/surah/102/) | Bermegah-Megahan | 8 |
+| 103 | [Al-'Asr](https://www.baca-quran.id/surah/103/) | Masa | 3 |
+| 104 | [Al-Humazah](https://www.baca-quran.id/surah/104/) | Pengumpat | 9 |
+| 105 | [Al-Fil](https://www.baca-quran.id/surah/105/) | Gajah | 5 |
+| 106 | [Quraisy](https://www.baca-quran.id/surah/106/) | Suku Quraisy | 4 |
+| 107 | [Al-Ma'un](https://www.baca-quran.id/surah/107/) | Barang Yang Berguna | 7 |
+| 108 | [Al-Kausar](https://www.baca-quran.id/surah/108/) | Nikmat Yang Banyak | 3 |
+| 109 | [Al-Kafirun](https://www.baca-quran.id/surah/109/) | Orang-Orang Kafir | 6 |
+| 110 | [An-Nasr](https://www.baca-quran.id/surah/110/) | Pertolongan | 3 |
+| 111 | [Al-Lahab](https://www.baca-quran.id/surah/111/) | Gejolak Api | 5 |
+| 112 | [Al-Ikhlas](https://www.baca-quran.id/surah/112/) | Memurnikan Keesaan Allah | 4 |
+| 113 | [Al-Falaq](https://www.baca-quran.id/surah/113/) | Waktu Subuh | 5 |
+| 114 | [An-Nas](https://www.baca-quran.id/surah/114/) | Manusia | 6 |
+
+## Makna dan Tema Utama Surat Juz 30
+
+Agar lebih mudah dipahami, surat-surat dalam Juz 30 dapat dikelompokkan berdasarkan tema besar yang dikandungnya.
+
+### Mengabarkan Hari Kiamat dan Kebangkitan
+
+Banyak surat di awal Juz 30 menggambarkan kedahsyatan hari kiamat dan kepastian hari kebangkitan. [An-Naba'](https://www.baca-quran.id/surah/78/) membahas "berita besar" yang dipertanyakan manusia, [At-Takwir](https://www.baca-quran.id/surah/81/) melukiskan saat matahari digulung, sedangkan [Al-Qari'ah](https://www.baca-quran.id/surah/101/) dan [Az-Zalzalah](https://www.baca-quran.id/surah/99/) menggambarkan guncangan dahsyat ketika bumi mengeluarkan seluruh isinya.
+
+### Mengajarkan Akhlak dan Mengingatkan Kehidupan Dunia
+
+Sebagian surat berisi teguran terhadap akhlak yang buruk. [Al-Humazah](https://www.baca-quran.id/surah/104/) mencela kebiasaan mengumpat dan menimbun harta, [Al-Ma'un](https://www.baca-quran.id/surah/107/) menyindir orang yang lalai dari menyantuni sesama, dan [At-Takasur](https://www.baca-quran.id/surah/102/) mengingatkan bahwa bermegah-megahan dapat melalaikan manusia. Adapun [Al-'Asr](https://www.baca-quran.id/surah/103/) menegaskan bahwa manusia berada dalam kerugian, kecuali yang beriman, beramal saleh, serta saling menasihati dalam kebenaran dan kesabaran.
+
+### Meneguhkan Tauhid dan Keimanan
+
+Beberapa surat menjadi inti penjagaan akidah seorang muslim. [Al-Ikhlas](https://www.baca-quran.id/surah/112/) menerangkan keesaan Allah secara ringkas namun padat, [Al-Kafirun](https://www.baca-quran.id/surah/109/) menegaskan batas yang jelas dalam keyakinan, sementara [Al-Falaq](https://www.baca-quran.id/surah/113/) dan [An-Nas](https://www.baca-quran.id/surah/114/) mengajarkan kita untuk senantiasa memohon perlindungan kepada Allah dari segala keburukan.
+
+### Mengandung Kisah dan Peristiwa Bersejarah
+
+Ada pula surat yang merekam peristiwa penting. [Al-Fil](https://www.baca-quran.id/surah/105/) mengisahkan gagalnya pasukan bergajah yang hendak menghancurkan Ka'bah, [Al-'Alaq](https://www.baca-quran.id/surah/96/) memuat wahyu pertama yang diterima Rasulullah, dan [Al-Qadr](https://www.baca-quran.id/surah/97/) menerangkan kemuliaan malam Lailatul Qadar yang lebih baik daripada seribu bulan.
+
+Sebagai penutup, mengenali arti nama dan tema setiap surat akan menambah kekhusyukan saat membacanya. Untuk mendalami lebih jauh, silakan baca [Daftar Lengkap Surat dalam Juz Amma](/2020-06-15-daftar-lengkap-surat-dalam-juz-amma-alquran-juz-30/) dan [Urutan Surat di Juz 30, Surat Sebelum dan Sesudahnya](/2026-05-28-urutan-surat-juz-30-sebelum-dan-sesudahnya/). Anda juga bisa membaca seluruh surat secara lengkap di [Baca-Quran.id](https://www.baca-quran.id/).


### PR DESCRIPTION
Implements Tier 3 of the content plan (#46), targeting the Juz 30 / Juz Amma supporting query clusters found in the GSC export.

## New articles
1. **Arti dan Makna Nama Surat dalam Juz 30** — full arti + jumlah-ayat table plus thematic groupings. Targets `arti surat juz 30`, `nama surat juz 30 dan artinya`, `nama surat juz 30 dan jumlah ayatnya`.
2. **Juz Amma Arab Saja, Membaca Juz 30 Tanpa Terjemahan** — targets `juz amma arab saja` (158 clicks, pos 1.5), `juz 30 lengkap arab tanpa terjemahan` (157 clicks); links to the reader and Setelan page, with Al-Ikhlas and An-Nas as Arabic examples.
3. **Surat-surat Pendek untuk Dihafal Anak dan Dibaca saat Sholat** — 15-surah table plus hafalan tips. Targets `surat pendek`, `15 surat pendek beserta artinya`, `10 surat terakhir juz 30`.

## Notes
- Follows the `AGENTS.md` conventions: formal but friendly Indonesian, no `--` separators, one to two punch-out links to baca-quran.id per article, internal cross-links to related posts.
- Publish dates staggered at 28 Apr, 1 May, and 4 May 2026 so they extend the existing 7–28 May cadence instead of pooling on one day.
- No duplication with the existing Juz Amma daftar article; this set is differentiated by theme/meaning, Arabic-only reading, and hafalan focus.

Closes #46.

## Test plan
- [ ] `pnpm build` succeeds and the three new posts render
- [ ] Internal cross-links and `/surah/{n}/` links resolve
- [ ] Tables display correctly on mobile

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTmgUngMZ6aBGRLBbzKn1C)_