### PR TITLE
CHORE: Update footer links to Web Tool Libraries

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -103,12 +103,8 @@ const Layout = ({ location, title, children }) => {
         </a>
         <br />
         <span>Cek juga: </span>
-        <a href="https://ksana.in/" target="_blank" rel="noopener noreferrer">
-          Ksana.in
-        </a>
-        <span>, </span>
-        <a href="https://www.tanyaaja.in/" target="_blank" rel="noopener noreferrer">
-          TanyaAja.in
+        <a href="https://tools.mazipan.space/" target="_blank" rel="noopener noreferrer">
+          Web Tool Libraries
         </a>
       </footer>
     </div>


### PR DESCRIPTION
Replaces the two "Cek juga" footer links (Ksana.in and TanyaAja.in) with a single link to `tools.mazipan.space` labelled **Web Tool Libraries**.

## Change
- `src/components/layout.js`: footer now shows `Cek juga: Web Tool Libraries` pointing to https://tools.mazipan.space/

## Test plan
- [ ] Footer renders the new link on the blog
- [ ] Link opens tools.mazipan.space in a new tab

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTmgUngMZ6aBGRLBbzKn1C)_