### PR TITLE
FIX: Make pagination prev/next links absolute

### DIFF
--- a/src/templates/blog-index.js
+++ b/src/templates/blog-index.js
@@ -14,8 +14,8 @@ const BlogIndex = ({ data, location, pageContext }) => {
   const { currentPage, numPages } = pageContext;
   const isFirst = currentPage === 1;
   const isLast = currentPage === numPages;
-  const prevPage = currentPage - 1 === 1 ? '/' : (currentPage - 1).toString();
-  const nextPage = (currentPage + 1).toString();
+  const prevPage = currentPage - 1 === 1 ? '/' : `/${currentPage - 1}`;
+  const nextPage = `/${currentPage + 1}`;
 
   return (
     <Layout location={location} title={siteTitle}>


### PR DESCRIPTION
## Problem
Previous/next navigation on the blog index (the `<<` / `>>` buttons) was broken.

## Root cause
In `src/templates/blog-index.js`, `prevPage` and `nextPage` were built as bare page numbers without a leading slash:

```js
const prevPage = currentPage - 1 === 1 ? '/' : (currentPage - 1).toString(); // "2", "3"...
const nextPage = (currentPage + 1).toString();                                // "2", "3"...
```

These are passed to the `<Link to={...}>` for the `<<` / `>>` controls in `pagination.js`. Because they lack a leading slash they are treated as **relative** URLs, so Gatsby's `pathPrefix` (`/tulisan`, applied via `--prefix-paths`) is not added and the link resolves against the current path. On `/tulisan/2/` the `>>` link pointed to `/tulisan/2/3` instead of `/tulisan/3`. The numbered page buttons worked only because they already use absolute paths (`` `/${i + 1}` ``).

## Fix
Build `prevPage` / `nextPage` as absolute paths, consistent with the numbered buttons:

```js
const prevPage = currentPage - 1 === 1 ? '/' : `/${currentPage - 1}`;
const nextPage = `/${currentPage + 1}`;
```

## Test plan
- [ ] `pnpm dev` (or `pnpm build && pnpm serve`), open the blog index
- [ ] `>>` advances `/tulisan/` → `/tulisan/2/` → `/tulisan/3/`
- [ ] `<<` goes back correctly, including page 2 → `/tulisan/`
- [ ] Numbered buttons still navigate correctly

## Note
Not running a full Gatsby build in CI-less review here; verified by code inspection. There is also a leftover `console.debug` at `blog-index.js:25` left untouched to keep this fix focused.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTmgUngMZ6aBGRLBbzKn1C)_