### PR TITLE
feat: auto-style Arabic text in blog posts with proper font and RTL alignment

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -65,6 +65,7 @@ module.exports = {
           },
           `gatsby-remark-prismjs`,
           require.resolve(`./plugins/gatsby-remark-table-wrapper`),
+          require.resolve(`./plugins/gatsby-remark-arabic-text`),
         ],
       },
     },

--- a/plugins/gatsby-remark-arabic-text/index.js
+++ b/plugins/gatsby-remark-arabic-text/index.js
@@ -1,0 +1,38 @@
+// Detects paragraph nodes containing Arabic characters and wraps them in a
+// div with class="font-arabic" dir="rtl" so they render with the correct
+// font, size, and right-to-left alignment without requiring manual markup
+// in every content file.
+module.exports = ({ markdownAST }) => {
+  // Covers Arabic (U+0600–U+06FF), Arabic Supplement, Arabic Extended-A,
+  // Arabic Presentation Forms-A and -B — enough to catch Quranic text.
+  const ARABIC_RE = /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-﻿]/;
+
+  const extractText = (node) => {
+    if (node.type === 'text') return node.value;
+    if (Array.isArray(node.children)) return node.children.map(extractText).join('');
+    return '';
+  };
+
+  const walk = (node) => {
+    if (!Array.isArray(node.children)) return;
+
+    // Walk in reverse so splicing doesn't shift unvisited indices
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      const child = node.children[i];
+      if (child.type === 'paragraph' && ARABIC_RE.test(extractText(child))) {
+        node.children.splice(
+          i,
+          1,
+          { type: 'html', value: '<div class="font-arabic" dir="rtl">' },
+          child,
+          { type: 'html', value: '</div>' }
+        );
+      } else {
+        walk(child);
+      }
+    }
+  };
+
+  walk(markdownAST);
+  return markdownAST;
+};

--- a/plugins/gatsby-remark-arabic-text/package.json
+++ b/plugins/gatsby-remark-arabic-text/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "gatsby-remark-arabic-text",
+  "version": "1.0.0",
+  "description": "Wraps Arabic-text paragraphs with font-arabic class and dir=rtl at build time",
+  "main": "index.js"
+}

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -1,5 +1,8 @@
 .font-arabic {
-  font-family: 'Noto Naskh Arabic', serif;
+  font-family: var(--font-arabic);
   font-size: 1.5rem;
   text-align: right;
+  direction: rtl;
+  line-height: 2;
+  display: block;
 }

--- a/src/html.js
+++ b/src/html.js
@@ -18,7 +18,7 @@ export default (props) => {
           crossOrigin="anonymous"
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,400;0,700;1,400&family=Montserrat:wght@400;500;600;700;800&family=Noto+Naskh+Arabic&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,400;0,700;1,400&family=Montserrat:wght@400;500;600;700;800&family=Noto+Naskh+Arabic:wght@400;700&display=swap"
           rel="stylesheet"
         />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1349,7 +1349,9 @@ tbody tr:last-child td {
   font-family: var(--font-arabic);
   font-size: 1.5rem;
   text-align: right;
+  direction: rtl;
   line-height: 2;
+  display: block;
 }
 
 /* ============================================


### PR DESCRIPTION
- Add gatsby-remark-arabic-text plugin that detects paragraph nodes
  containing Arabic Unicode characters at build time and wraps them in
  <div class="font-arabic" dir="rtl"> — no manual markup needed in
  content files
- Register the plugin in gatsby-config.js after the table-wrapper plugin
- Add direction: rtl and display: block to .font-arabic in both
  global.css and layout.css, and consolidate to use --font-arabic CSS var
- Load Noto Naskh Arabic with wght@400;700 from Google Fonts so bold
  Arabic text (strong/em) renders correctly

https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE