### PR TITLE
fix: correct Arabic text styling for inline and block cases

### DIFF
--- a/content/blog/2023-07-31-doa-pembuka-pintu-rezeki/index.md
+++ b/content/blog/2023-07-31-doa-pembuka-pintu-rezeki/index.md
@@ -37,7 +37,7 @@ Doa saja tidaklah cukup tanpa tiga pilar ini, dan ketiganya saling menguatkan sa
 ### Doa pembuka pintu rezeki 1
 
 <section>
-  <p class="font-arabic">
+  <p class="font-arabic" dir="rtl">
     أَصْبَحْنَا وَأَصْبَحَ الْمُلْكُ لِلَّهِ، وَالْحَمْدُ لِلَّهِ، لاَ إِلَـهَ إِلاَّ اللهُ وَحْدَهُ
     لاَ شَرِيْكَ لَهُ، لَهُ الْمُلْكُ وَلَهُ الْحَمْدُ وَهُوَ عَلَى كُلِّ شَيْءٍ قَدِيْرُ. رَبِّ أَسْأَلُكَ خَيْرَ مَا فِيْ هَذَا الْيَوْمِ وَخَيْرَ مَا بَعْدَهُ، وَأَعُوْذُ بِكَ مِنْ شَرِّ مَا فِيْ هَذَا الْيَوْمِ وَشَرِّ مَا بَعْدَهُ، رَبِّ أَعُوْذُ بِكَ مِنَ الْكَسَلِ وَسُوْءِ الْكِبَرِ، رَبِّ أَعُوْذُ بِكَ مِنْ عَذَابٍ فِي النَّارِ وَعَذَابٍ فِي الْقَبْرِ
   </p>
@@ -54,7 +54,7 @@ Doa ini adalah doa pagi yang sangat dianjurkan. Membuka hari dengan pengakuan ba
 ### Doa pembuka pintu rezeki 2
 
 <section>
-  <p class="font-arabic">
+  <p class="font-arabic" dir="rtl">
     رَضِيْتُ بِاللهِ رَبًّا، وَبِاْلإِسْلاَمِ دِيْنًا، وَبِمُحَمَّدٍ صَلَّى اللهُ عَلَيْهِ وَسَلَّمَ نَبِيًّا
   </p>
   <b>Terjemahan:</b>
@@ -68,7 +68,7 @@ Doa yang singkat namun sangat dalam ini adalah pernyataan kepuasan dan penerimaa
 ### Doa pembuka pintu rezeki 3
 
 <section>
-  <p class="font-arabic">
+  <p class="font-arabic" dir="rtl">
     بِسْمِ اللهِ عَلَى نَفْسِي وَمَالِي وَدِيْنِيْ. اَللَّهُمَّ رَضِّنِيْ بِقَضَائِكَ، وَبَارِكْ لِيْ فِيْمَا قُدِّرَ لِيْ حَتَّى لَا أُحِبَّ تَعْجِيْلَ مَا أَخَّرْتَ وَلَا تَأْخِيْرَ مَا عَجَّلْتَ
   </p>
   <b>Terjemahan:</b>

--- a/content/blog/2023-08-04-menemukan-ketenangan-hati-melalui-tilawah-alquran/index.md
+++ b/content/blog/2023-08-04-menemukan-ketenangan-hati-melalui-tilawah-alquran/index.md
@@ -13,7 +13,7 @@ Tilawah Al-Quran adalah tindakan membaca Al-Quran dengan penuh perenungan dan ke
 ### [Surah Ar-Ra'd (13): Ayat 28](https://www.baca-quran.id/surah/13/28/)
 
 <section>
-  <p class="font-arabic">
+  <p class="font-arabic" dir="rtl">
     الَّذِيْنَ اٰمَنُوْا وَتَطْمَىِٕنُّ قُلُوْبُهُمْ بِذِكْرِ اللّٰهِ ۗ اَلَا بِذِكْرِ اللّٰهِ تَطْمَىِٕنُّ الْقُلُوْبُ
   </p>
   <b>Terjemahan:</b>
@@ -25,7 +25,7 @@ Tilawah Al-Quran adalah tindakan membaca Al-Quran dengan penuh perenungan dan ke
 ### [Surah Az-Zumar (39): Ayat 23](https://www.baca-quran.id/surah/39/23/)
 
 <section>
-  <p class="font-arabic">
+  <p class="font-arabic" dir="rtl">
     اَللّٰهُ نَزَّلَ اَحْسَنَ الْحَدِيْثِ كِتٰبًا مُّتَشَابِهًا مَّثَانِيَۙ تَقْشَعِرُّ مِنْهُ جُلُوْدُ الَّذِيْنَ يَخْشَوْنَ رَبَّهُمْ ۚ ثُمَّ تَلِيْنُ جُلُوْدُهُمْ وَقُلُوْبُهُمْ اِلٰى ذِكْرِ اللّٰهِ ۗذٰلِكَ هُدَى اللّٰهِ يَهْدِيْ بِهٖ مَنْ يَّشَاۤءُ ۗوَمَنْ يُّضْلِلِ اللّٰهُ فَمَا لَهٗ مِنْ هَادٍ
   </p>
   <b>Terjemahan:</b>

--- a/plugins/gatsby-remark-arabic-text/index.js
+++ b/plugins/gatsby-remark-arabic-text/index.js
@@ -1,11 +1,18 @@
-// Detects paragraph nodes containing Arabic characters and wraps them in a
-// div with class="font-arabic" dir="rtl" so they render with the correct
-// font, size, and right-to-left alignment without requiring manual markup
-// in every content file.
+// At build time, finds Arabic text in markdown and applies proper styling:
+//   - Paragraphs that are ≥40% Arabic chars → wrapped as a right-aligned Arabic block
+//   - Paragraphs that contain some Arabic but are mostly Latin → inline Arabic
+//     runs are wrapped with <bdi class="font-arabic-inline"> for bidirectional
+//     isolation without reversing the whole paragraph direction
 module.exports = ({ markdownAST }) => {
-  // Covers Arabic (U+0600–U+06FF), Arabic Supplement, Arabic Extended-A,
-  // Arabic Presentation Forms-A and -B — enough to catch Quranic text.
-  const ARABIC_RE = /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-﻿]/;
+  // Basic Arabic block + Supplement + Extended-A + Presentation Forms A/B
+  const ARABIC_RE =
+    /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]/;
+  const ARABIC_SPLIT_RE =
+    /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]+/g;
+
+  // Treat paragraph as an Arabic block only when ≥40% of non-space chars
+  // are Arabic. Inline quoted Arabic phrases stay well below this.
+  const BLOCK_THRESHOLD = 0.4;
 
   const extractText = (node) => {
     if (node.type === 'text') return node.value;
@@ -13,20 +20,73 @@ module.exports = ({ markdownAST }) => {
     return '';
   };
 
+  const arabicRatio = (text) => {
+    const stripped = text.replace(/\s/g, '');
+    if (!stripped.length) return 0;
+    const count = (stripped.match(/[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]/g) || []).length;
+    return count / stripped.length;
+  };
+
+  // Split one text string into an array of remark nodes, wrapping Arabic runs
+  // in <bdi class="font-arabic-inline"> inline HTML nodes.
+  const splitTextNode = (value) => {
+    const nodes = [];
+    let lastIndex = 0;
+    ARABIC_SPLIT_RE.lastIndex = 0;
+    let match;
+    while ((match = ARABIC_SPLIT_RE.exec(value)) !== null) {
+      if (match.index > lastIndex) {
+        nodes.push({ type: 'text', value: value.slice(lastIndex, match.index) });
+      }
+      nodes.push({
+        type: 'html',
+        value: `<bdi class="font-arabic-inline">${match[0]}</bdi>`,
+      });
+      lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < value.length) {
+      nodes.push({ type: 'text', value: value.slice(lastIndex) });
+    }
+    return nodes.length ? nodes : [{ type: 'text', value }];
+  };
+
+  // Recursively walk inline nodes and split any text node that contains Arabic
+  const wrapInlineArabic = (nodes) =>
+    nodes.flatMap((node) => {
+      if (node.type === 'text' && ARABIC_RE.test(node.value)) {
+        return splitTextNode(node.value);
+      }
+      if (Array.isArray(node.children)) {
+        return [{ ...node, children: wrapInlineArabic(node.children) }];
+      }
+      return [node];
+    });
+
   const walk = (node) => {
     if (!Array.isArray(node.children)) return;
 
     // Walk in reverse so splicing doesn't shift unvisited indices
     for (let i = node.children.length - 1; i >= 0; i--) {
       const child = node.children[i];
-      if (child.type === 'paragraph' && ARABIC_RE.test(extractText(child))) {
-        node.children.splice(
-          i,
-          1,
-          { type: 'html', value: '<div class="font-arabic" dir="rtl">' },
-          child,
-          { type: 'html', value: '</div>' }
-        );
+      if (child.type === 'paragraph') {
+        const text = extractText(child);
+        if (!ARABIC_RE.test(text)) {
+          walk(child);
+          continue;
+        }
+        if (arabicRatio(text) >= BLOCK_THRESHOLD) {
+          // Mostly Arabic: render as a right-aligned Arabic text block
+          node.children.splice(
+            i,
+            1,
+            { type: 'html', value: '<div class="font-arabic" dir="rtl">' },
+            child,
+            { type: 'html', value: '</div>' }
+          );
+        } else {
+          // Mixed paragraph: isolate only the Arabic runs inline with <bdi>
+          child.children = wrapInlineArabic(child.children);
+        }
       } else {
         walk(child);
       }

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -6,3 +6,8 @@
   line-height: 2;
   display: block;
 }
+
+.font-arabic-inline {
+  font-family: var(--font-arabic);
+  font-size: 1.2em;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1433,6 +1433,11 @@ tbody tr:last-child td {
   display: block;
 }
 
+.font-arabic-inline {
+  font-family: var(--font-arabic);
+  font-size: 1.2em;
+}
+
 /* ============================================
    RESPONSIVE
    ============================================ */


### PR DESCRIPTION
## Summary

- Mixed paragraphs (mostly Latin with inline Arabic quotes) were incorrectly getting the full block wrap (`div.font-arabic dir="rtl"`), which right-aligned the entire paragraph. Now the plugin calculates the Arabic character ratio: paragraphs ≥40% Arabic get the block wrap, while those below threshold get individual Arabic runs wrapped with `<bdi class="font-arabic-inline">` for proper bidirectional isolation
- Add `.font-arabic-inline` CSS class (font-family + 1.2em size only — no block/RTL layout properties) for inline `<bdi>` use
- Fix two posts with pre-existing manual `<p class="font-arabic">` that were missing `dir="rtl"` — without the HTML attribute, the browser's Unicode bidirectional algorithm doesn't correctly place punctuation/numbers within RTL runs

## Test plan

- [x] Build passes cleanly (`gatsby build`) on all 41 pages
- [x] `daftar-lengkap-surat-dalam-juz-amma` — first paragraph no longer right-aligned; Arabic phrase `عَمَّ يَتَسَاۤءَلُوْنَۚ` isolated with `<bdi>` inline
- [x] `juz-amma-arab-saja-tanpa-terjemahan` — all 12 Quranic verses still get full block wrap with `dir="rtl"`
- [x] `doa-pembuka-pintu-rezeki` and `menemukan-ketenangan-hati` — manual `<p>` elements now have `dir="rtl"` attribute
- [x] Full audit of all built HTML confirms zero unwrapped Arabic paragraphs and zero manual elements missing `dir` attribute

https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE)_