### PR TITLE
fix: wrap whole Arabic phrase in one bdi to preserve RTL word order

### DIFF
--- a/plugins/gatsby-remark-arabic-text/index.js
+++ b/plugins/gatsby-remark-arabic-text/index.js
@@ -7,8 +7,10 @@ module.exports = ({ markdownAST }) => {
   // Basic Arabic block + Supplement + Extended-A + Presentation Forms A/B
   const ARABIC_RE =
     /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]/;
+  // Also matches spaces *between* Arabic words so the whole phrase lands in
+  // one <bdi> and maintains correct RTL word order as a single inline unit.
   const ARABIC_SPLIT_RE =
-    /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]+/g;
+    /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]+(?:\s+[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]+)*/g;
 
   // Treat paragraph as an Arabic block only when ≥40% of non-space chars
   // are Arabic. Inline quoted Arabic phrases stay well below this.
@@ -40,7 +42,7 @@ module.exports = ({ markdownAST }) => {
       }
       nodes.push({
         type: 'html',
-        value: `<bdi class="font-arabic-inline">${match[0]}</bdi>`,
+        value: `<bdi class="font-arabic-inline" dir="rtl">${match[0]}</bdi>`,
       });
       lastIndex = match.index + match[0].length;
     }


### PR DESCRIPTION
## Problem

Inline Arabic phrases (e.g. `عَمَّ يَتَسَاۤءَلُوْنَۚ` embedded in a Latin paragraph) were being split into one `<bdi>` per word, with an LTR space between them. The browser placed each `<bdi>` left-to-right in the line, reversing the RTL word order and causing the phrase to break across lines — as seen in the screenshot below.

## Fix

Updated `ARABIC_SPLIT_RE` in the `gatsby-remark-arabic-text` plugin to use:

```
/[Arabic]+(?:\s+[Arabic]+)*/g
```

This greedily extends each match to include spaces followed by more Arabic characters, so an entire Arabic phrase lands in a single `<bdi dir="rtl">` and the browser treats it as one cohesive RTL unit with correct word order.

**Before:**
```html
…berbunyi <bdi>عَمَّ</bdi> <bdi>يَتَسَاۤءَلُوْنَۚ</bdi> ('Amma…
```

**After:**
```html
…berbunyi <bdi dir="rtl">عَمَّ يَتَسَاۤءَلُوْنَۚ</bdi> ('Amma…
```

## Test plan

- [x] Build passes cleanly on all 41 pages
- [x] `daftar-lengkap-surat-dalam-juz-amma` — Arabic phrase renders as a single inline RTL unit, no split across lines

https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE)_