### PR TITLE
fix: preserve image aspect ratio by overriding gatsby-remark-images positioning

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -384,6 +384,18 @@ tbody tr:last-child td {
   box-shadow: var(--card-shadow);
 }
 
+.gatsby-resp-image-background-image {
+  display: none !important;
+}
+
+.gatsby-resp-image-image {
+  position: static !important;
+  width: 100% !important;
+  height: auto !important;
+  margin: 0 !important;
+  display: block;
+}
+
 /* ============================================
    LAYOUT ROOT
    ============================================ */


### PR DESCRIPTION
gatsby-remark-images uses a padding-bottom aspect-ratio trick where the inner
<img> has position:absolute and height:100% as inline styles. CSS class rules
cannot override inline styles, so if the wrapper dimensions don't perfectly
match the image's natural ratio the image appears stretched.

Switch to static positioning with height:auto so the browser computes the
correct proportional height from the image's natural dimensions, regardless
of the configured maxWidth.

https://claude.ai/code/session_01EDzCWKytuRrjzbt7JKPfb2