### PR TITLE
Replace span with bdi for inline Arabic text

### DIFF
--- a/content/blog/2020-06-13-keutamaan-membaca-surat-al-kahfi-pada-malam-jumat/index.md
+++ b/content/blog/2020-06-13-keutamaan-membaca-surat-al-kahfi-pada-malam-jumat/index.md
@@ -58,7 +58,7 @@ Ketika para sahabat lulus dari 4 fitnah di atas. Maka Allah memberikan pujian ya
 Demikian istimewanya surat ini, hingga Rasulullah Shallallahu ‘alaihi wa sallam jadikan sebagai sumber cahaya bagi manusia. Sehingga mereka terhindari dari fitnah Dajjal, fitnah dunia, dan agama. Tentu saja, ini bagi mereka yang berusaha merenungi kandungan isi dan maknanya.
 
 Ditulis Oleh:
-Ustadz Abu Rufaydah, Lc. MA <span class="arabic">حفظه الله</span> (Kontributor Bimbinganislam.com)
+Ustadz Abu Rufaydah, Lc. MA <bdi class="arabic">حفظه الله</bdi> (Kontributor Bimbinganislam.com)
 
 Referensi: https://bimbinganislam.com/keutamaan-surat-al-kahfi-di-malam-jumat/
 

--- a/content/blog/2020-06-15-daftar-lengkap-surat-dalam-juz-amma-alquran-juz-30/index.md
+++ b/content/blog/2020-06-15-daftar-lengkap-surat-dalam-juz-amma-alquran-juz-30/index.md
@@ -4,7 +4,7 @@ description: Daftar lengkap dan urutan surat dalam Juz Amma (Al-Quran Juz 30) ya
 date: '2024-12-04T23:59:59.121Z'
 ---
 
-**Juz 30** dalam Al-Quran dikenal dengan **[Juz Amma](https://www.baca-quran.id/juz-amma/)** karena diawali dengan Surat An-Naba' yang diawali dengan ayat yang berbunyi <span class="arabic">عَمَّ يَتَسَاۤءَلُوْنَۚ</span> ('Amma yatasaaa aluun).
+**Juz 30** dalam Al-Quran dikenal dengan **[Juz Amma](https://www.baca-quran.id/juz-amma/)** karena diawali dengan Surat An-Naba' yang diawali dengan ayat yang berbunyi <bdi class="arabic">عَمَّ يَتَسَاۤءَلُوْنَۚ</bdi> ('Amma yatasaaa aluun).
 
 Juz 30 merupakan juz terakhir atau pamungkas dari keseluruhan isi Al-Quran yang dimulai dari Surat Al-fatihah dan diteruskan dengan Surat Al-Baqarah sampai ke An-Nas.
 
@@ -81,7 +81,7 @@ Daftar lengkap 37 surat dalam Juz 30 beserta arti dan jumlah ayatnya bisa Anda l
 
 **Mengapa Juz 30 disebut Juz Amma?**
 
-Juz 30 disebut Juz Amma karena diawali oleh surat An-Naba' yang dibuka dengan ayat berbunyi <span class="arabic">عَمَّ يَتَسَاۤءَلُوْنَۚ</span> ('Amma yatasaa aluun), sehingga kata "Amma" kemudian melekat menjadi nama populer untuk juz ini.
+Juz 30 disebut Juz Amma karena diawali oleh surat An-Naba' yang dibuka dengan ayat berbunyi <bdi class="arabic">عَمَّ يَتَسَاۤءَلُوْنَۚ</bdi> ('Amma yatasaa aluun), sehingga kata "Amma" kemudian melekat menjadi nama populer untuk juz ini.
 
 **Berapa banyak surat pendek dalam Juz 30?**
 

--- a/content/blog/2020-06-17-ayat-sajdah-dan-sujud-tilawah/index.md
+++ b/content/blog/2020-06-17-ayat-sajdah-dan-sujud-tilawah/index.md
@@ -4,7 +4,7 @@ description: Ayat-ayat sajdah dalam Al-Quran serta penjelasan Sujud tilawah keti
 date: '2020-06-17T23:59:59.121Z'
 ---
 
-Ayat Sajdah (<span class="arabic">اٰية السجدة</span>) adalah ayat-ayat tertentu dalam [Al Qur'an](https://www.baca-quran.id/) yang bila dibaca disunnahkan bagi yang membaca dan mendengarnya untuk melakukan sujud tilawah.
+Ayat Sajdah (<bdi class="arabic">اٰية السجدة</bdi>) adalah ayat-ayat tertentu dalam [Al Qur'an](https://www.baca-quran.id/) yang bila dibaca disunnahkan bagi yang membaca dan mendengarnya untuk melakukan sujud tilawah.
 
 ![Sujud](316-pai04129-eye.jpg)
 Photo by [Chanikarn Thongsupa](https://www.rawpixel.com/pai) from [Rawpixel](https://www.rawpixel.com/image/425647/free-photo-image-muslim-muslim-praying-sujood)


### PR DESCRIPTION
## Summary

- Replace `<span class="arabic">` with `<bdi class="arabic">` for all inline Arabic phrases in mixed-direction paragraphs
- Affects 3 blog posts (4 occurrences total): Al-Kahfi, Juz Amma, and Ayat Sajdah articles
- `<bdi>` (bidirectional isolation) is the semantically correct element for embedding RTL text within LTR content

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] Inline Arabic phrases render with correct font in each affected post
- [ ] Surrounding Latin text direction is unaffected

https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE)_