### PR TITLE
Add direction: rtl to .arabic CSS class

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -9,4 +9,5 @@
 
 .arabic {
   font-family: var(--font-arabic);
+  direction: rtl;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1447,6 +1447,7 @@ tbody tr:last-child td {
 
 .arabic {
   font-family: var(--font-arabic);
+  direction: rtl;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary

- Adds `direction: rtl` to the `.arabic` CSS class in both `src/styles/global.css` and `src/components/layout.css`
- Ensures inline Arabic text within `<bdi class="arabic">` elements renders right-to-left

## Test plan

- [ ] Build passes
- [ ] Inline Arabic phrases display in correct RTL direction

https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4FW4tPPyzFVouhTT1LBcE)_