### PR TITLE
Fix /schedule skill: add YAML colon rule

### DIFF
--- a/.claude/skills/schedule/SKILL.md
+++ b/.claude/skills/schedule/SKILL.md
@@ -31,6 +31,7 @@ Before writing anything, present a plan to the user:
 For each article:
 - Create the folder `content/blog/YYYY-MM-DD-slug/` with `index.md` inside
 - Follow all writing rules from AGENTS.md (tone, length, format, no em-dashes, bold-headed paragraphs, etc.)
+- **YAML rule**: if `title` or `description` contains a colon (`:`), wrap the whole value in double quotes — e.g. `title: "Judul: Subjudul"`. Unquoted colons break the YAML parser and fail CI.
 - Include at least one link to `https://www.baca-quran.id/` or a subpage
 - Cross-link to related articles using relative paths like `[Title](/slug/)`
 


### PR DESCRIPTION
Adds one missing rule to the `/schedule` skill:

> **YAML rule**: if `title` or `description` contains a colon (`:`), wrap the whole value in double quotes — e.g. `title: "Judul: Subjudul"`. Unquoted colons break the YAML parser and fail CI.

This was the root cause of CI failures on PRs #78, #79, #80, and #82. Those PRs have already been fixed directly on their branches. This PR prevents the same mistake from happening in future `/schedule` runs.

https://claude.ai/code/session_01Wrcfc5iAdKgvxrGdNLAnTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wrcfc5iAdKgvxrGdNLAnTx)_