### PR TITLE
ci: add auto-rebase workflow for stale automerge PRs

### DIFF
--- a/.claude/skills/schedule/SKILL.md
+++ b/.claude/skills/schedule/SKILL.md
@@ -50,6 +50,7 @@ For **each article separately**:
    [publish: YYYY-MM-DD] CONTENT: Article Title Here
    ```
    The `[publish: YYYY-MM-DD]` token is mandatory — the `scheduled-merge.yml` workflow uses it to auto-merge on the right date.
+5. Add the **`scheduled`** label to the PR.
 
 **Never put multiple articles in one PR. Never use the same branch for two articles.**
 

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,105 @@
+name: Auto-Rebase
+
+# Updates stale automerge PRs that are behind master but have no conflicts.
+#
+# Complements Kodiak's own [update] always = true setting as a fallback.
+# Uses GitHub's update-branch API (merge-style update, no force-push needed).
+#
+# Skips PRs where mergeable_state is:
+#   - 'dirty'   → has conflicts, manual resolution required
+#   - 'clean'   → already up-to-date, nothing to do
+#   - 'blocked' → waiting on reviews/checks, Kodiak will handle once unblocked
+#   - 'unknown' → GitHub hasn't computed mergeability yet (retried up to 5×)
+
+on:
+  schedule:
+    - cron: '0 17 */2 * *' # ~00:00 WIB, every 2 days (same cadence as scheduled-merge)
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-stale-prs:
+    # For label events, only run when the added label is 'automerge'
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'automerge'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Update stale automerge PRs
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const AUTOMERGE_LABEL = 'automerge';
+
+            // GitHub computes mergeability asynchronously; poll until resolved.
+            async function fetchMergeableState(prNumber) {
+              for (let attempt = 1; attempt <= 5; attempt++) {
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                if (data.mergeable !== null) return data;
+                core.info(`PR #${prNumber}: mergeability pending (attempt ${attempt}/5), waiting 3 s…`);
+                await new Promise(r => setTimeout(r, 3000));
+              }
+              return null;
+            }
+
+            // Collect PRs to inspect.
+            let candidates;
+            if (context.eventName === 'pull_request') {
+              // Triggered by label event — only inspect this specific PR.
+              candidates = [context.payload.pull_request];
+            } else {
+              candidates = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                base: 'master',
+                per_page: 100,
+              });
+            }
+
+            let updated = 0;
+            for (const pr of candidates) {
+              if (pr.draft) continue;
+
+              const hasLabel = pr.labels.some(l => l.name === AUTOMERGE_LABEL);
+              if (!hasLabel) continue;
+
+              const fullPr = await fetchMergeableState(pr.number);
+              if (!fullPr) {
+                core.warning(`PR #${pr.number}: could not determine mergeability after retries, skipping.`);
+                continue;
+              }
+
+              const { mergeable_state: state } = fullPr;
+
+              if (state !== 'behind') {
+                core.info(`PR #${pr.number}: mergeable_state='${state}', no update needed.`);
+                continue;
+              }
+
+              // 'behind' means stale but no conflicts — safe to update.
+              core.info(`PR #${pr.number} is behind master. Updating branch…`);
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                core.info(`PR #${pr.number} updated successfully.`);
+                updated++;
+              } catch (err) {
+                core.warning(`PR #${pr.number} update failed: ${err.message}`);
+              }
+            }
+
+            core.info(`Done. Updated ${updated} PR(s).`);

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -14,8 +14,12 @@ automerge_label = "automerge" # default: "automerge"
 # GitHub branch protection requirements.
 require_automerge_label = true
 
+# Rebase the PR branch on top of the base branch instead of creating a merge commit.
+method = "rebase"
+
 [update]
 always = true # default: false
+always_update = true # update PRs with automerge label whenever the base branch changes
 ignored_usernames = ["dependabot", "snyk-bot"]
 
 [approve]

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,10 +1,38 @@
 version = 1
 
-[update]
-# Automatically rebases/updates the PR when the base branch changes
-always_update = true
-
 [merge]
-# Ensures the final merge uses the rebase method
+# Label to enable Kodiak to merge a PR.
+
+# By default, Kodiak will only act on PRs that have this label. You can disable
+# this requirement via `merge.require_automerge_label`.
+automerge_label = "automerge" # default: "automerge"
+
+# Require that the automerge label (`merge.automerge_label`) be set for Kodiak
+# to merge a PR.
+#
+# When disabled, Kodiak will immediately attempt to merge any PR that passes all
+# GitHub branch protection requirements.
+require_automerge_label = true
+
+# Rebase the PR branch on top of the base branch instead of creating a merge commit.
 method = "rebase"
-automerge_label = "automerge"
+
+[update]
+always = true # default: false
+always_update = true # update PRs with automerge label whenever the base branch changes
+ignored_usernames = ["dependabot", "snyk-bot"]
+
+[approve]
+auto_approve_usernames = ["ImgBotApp", "imgbot"]
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["dependabot", "snyk-bot"]
+
+# https://kodiakhq.com/docs/recipes#better-merge-messages
+[merge.message]
+
+title = "pull_request_title" # default: "github_default"
+body = "pull_request_body" # default: "github_default"
+include_pr_number = true
+include_coauthors = true

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -14,8 +14,8 @@ automerge_label = "automerge" # default: "automerge"
 # GitHub branch protection requirements.
 require_automerge_label = true
 
-# Rebase the PR branch on top of the base branch instead of creating a merge commit.
-method = "rebase"
+# Squash all PR commits into a single commit when merging, keeping history clean.
+method = "squash"
 
 [update]
 always = true # default: false

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,38 +1,10 @@
 version = 1
 
-[merge]
-# Label to enable Kodiak to merge a PR.
-
-# By default, Kodiak will only act on PRs that have this label. You can disable
-# this requirement via `merge.require_automerge_label`.
-automerge_label = "automerge" # default: "automerge"
-
-# Require that the automerge label (`merge.automerge_label`) be set for Kodiak
-# to merge a PR.
-#
-# When disabled, Kodiak will immediately attempt to merge any PR that passes all
-# GitHub branch protection requirements.
-require_automerge_label = true
-
-# Rebase the PR branch on top of the base branch instead of creating a merge commit.
-method = "rebase"
-
 [update]
-always = true # default: false
-always_update = true # update PRs with automerge label whenever the base branch changes
-ignored_usernames = ["dependabot", "snyk-bot"]
+# Automatically rebases/updates the PR when the base branch changes
+always_update = true
 
-[approve]
-auto_approve_usernames = ["ImgBotApp", "imgbot"]
-
-[merge.automerge_dependencies]
-versions = ["minor", "patch"]
-usernames = ["dependabot", "snyk-bot"]
-
-# https://kodiakhq.com/docs/recipes#better-merge-messages
-[merge.message]
-
-title = "pull_request_title" # default: "github_default"
-body = "pull_request_body" # default: "github_default"
-include_pr_number = true
-include_coauthors = true
+[merge]
+# Ensures the final merge uses the rebase method
+method = "rebase"
+automerge_label = "automerge"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,8 @@ Untuk artikel musiman yang harus terbit pada tanggal tertentu (misalnya konten t
 3. Buat satu Pull Request terpisah untuk setiap artikel terjadwal, agar tiap artikel bisa terbit pada tanggalnya masing-masing.
 4. Cantumkan token tanggal pada **judul PR** dengan format `[publish: YYYY-MM-DD]`, contohnya:
    `[publish: 2026-06-05] CONTENT: Amalan dan Keutamaan Bulan Muharram`
-5. Biarkan PR tetap terbuka. Token pada judul inilah yang menjadi penanda jadwal sekaligus sumber tanggal terbitnya.
+5. Tambahkan label **`scheduled`** pada PR tersebut untuk memudahkan identifikasi dan pengelompokan konten terjadwal.
+6. Biarkan PR tetap terbuka. Token pada judul inilah yang menjadi penanda jadwal sekaligus sumber tanggal terbitnya.
 
 **Cara kerja otomatisasinya:**
 


### PR DESCRIPTION
Adds a workflow that finds open PRs with the `automerge` label whose
branches are behind master but have no conflicts (`mergeable_state ==
'behind'`), and updates them via GitHub's update-branch API.

Triggers on the same schedule as scheduled-merge, on workflow_dispatch,
and immediately when the `automerge` label is added to a PR.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DioHK515sVBGsCLuGw9exh