### PR TITLE
feat: floating theme toggle, improved hero contrast, add games link

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -76,9 +76,6 @@ const Layout = ({ location, title, children }) => {
             )}
           </div>
 
-          <div className="site-header__actions">
-            <ThemeToggle />
-          </div>
         </div>
       </header>
 
@@ -234,6 +231,14 @@ const Layout = ({ location, title, children }) => {
             </a>
             <a
               className="site-footer__link"
+              href="https://games.mazipan.space/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Games
+            </a>
+            <a
+              className="site-footer__link"
               href="https://mazipan.space/"
               target="_blank"
               rel="noopener noreferrer"
@@ -249,6 +254,8 @@ const Layout = ({ location, title, children }) => {
           <span>Built with ❤️ by Irfan Maulana</span>
         </div>
       </footer>
+
+      <ThemeToggle />
     </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,7 +85,7 @@
   --badge-border: #c7d2fe;
 
   --hero-text: #f8fafc;
-  --hero-text-muted: #94a3b8;
+  --hero-text-muted: #cbd5e1;
   --hero-accent: #818cf8;
   --hero-border: rgba(255, 255, 255, 0.08);
   --hero-badge-bg: rgba(129, 140, 248, 0.2);
@@ -158,7 +158,7 @@
   --badge-border: #312e81;
 
   --hero-text: #f1f5f9;
-  --hero-text-muted: #64748b;
+  --hero-text-muted: #94a3b8;
   --hero-accent: #818cf8;
   --hero-border: rgba(255, 255, 255, 0.06);
   --hero-badge-bg: rgba(129, 140, 248, 0.15);
@@ -479,33 +479,31 @@ tbody tr:last-child td {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
-.site-header__actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-shrink: 0;
-}
-
-/* Theme Toggle Button */
+/* Theme Toggle Button — floating action button, bottom-right */
 .theme-toggle {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 1000;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: var(--radius);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--header-text);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent);
+  color: #ffffff;
   cursor: pointer;
   padding: 0;
-  transition: background-color var(--transition), border-color var(--transition), transform var(--transition);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: background-color var(--transition), transform var(--transition), box-shadow var(--transition);
 }
 
 .theme-toggle:hover {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.22);
-  transform: scale(1.05);
+  background: var(--accent-hover);
+  transform: scale(1.08);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3), 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .theme-toggle:active {
@@ -513,8 +511,8 @@ tbody tr:last-child td {
 }
 
 .theme-toggle svg {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   flex-shrink: 0;
 }
 
@@ -741,7 +739,7 @@ tbody tr:last-child td {
   font-family: var(--font-sans);
   font-size: 0.6875rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--hero-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   margin-top: 0.375rem;


### PR DESCRIPTION
- Move ThemeToggle from header to a fixed bottom-right FAB so it remains
  accessible when scrolled away from the top
- Improve hero section text contrast: raise --hero-text-muted from #94a3b8
  (light) / #64748b (dark) to #cbd5e1 / #94a3b8 respectively, and switch
  .hero__stat-label from a hardcoded dim grey to var(--hero-text-muted)
- Add games.mazipan.space link in the footer Tautan section below web tools

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Scmx38DYEi2iWVuiau5X6Q