### PR TITLE
feat: add client-side search page

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,6 +1,24 @@
 import React, { useEffect } from 'react';
 import { Link } from 'gatsby';
 
+const SearchIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={18}
+    height={18}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.35-4.35" />
+  </svg>
+);
+
 import ThemeToggle from './ThemeToggle';
 import './layout.css';
 import '../styles/global.css';
@@ -76,6 +94,16 @@ const Layout = ({ location, title, children }) => {
             )}
           </div>
 
+          <nav className="site-header__nav" aria-label="Navigasi tambahan">
+            <Link
+              to="/search"
+              className="site-header__search"
+              aria-label="Cari artikel"
+            >
+              <SearchIcon />
+              <span className="site-header__search-label">Cari</span>
+            </Link>
+          </nav>
         </div>
       </header>
 

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,0 +1,236 @@
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { Link, useStaticQuery, graphql } from 'gatsby';
+
+import Layout from '../components/layout';
+import MetaHead from '../components/MetaHead';
+import AbstractPattern from '../components/AbstractPattern';
+
+const SearchIcon = ({ size = 20 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.35-4.35" />
+  </svg>
+);
+
+const ArrowRightIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={13}
+    height={13}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+  </svg>
+);
+
+function searchPosts(posts, rawQuery) {
+  const q = rawQuery.trim().toLowerCase();
+  if (!q) return [];
+  const terms = q.split(/\s+/);
+  return posts.filter(post => {
+    const haystack = [
+      post.frontmatter.title,
+      post.frontmatter.description,
+      post.excerpt,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return terms.every(term => haystack.includes(term));
+  });
+}
+
+const SearchPage = ({ location }) => {
+  const data = useStaticQuery(graphql`
+    query SearchQuery {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+      allMarkdownRemark(sort: { frontmatter: { date: DESC } }) {
+        nodes {
+          excerpt(pruneLength: 160)
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+            description
+            date(formatString: "DD MMM YYYY")
+            dateISO: date(formatString: "YYYY-MM-DD")
+          }
+        }
+      }
+    }
+  `);
+
+  const siteTitle = data.site.siteMetadata.title;
+  const allPosts = data.allMarkdownRemark.nodes;
+
+  const [query, setQuery] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(location.search);
+      setQuery(params.get('q') || '');
+    }
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [location.search]);
+
+  const handleChange = e => {
+    const val = e.target.value;
+    setQuery(val);
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (val) {
+        url.searchParams.set('q', val);
+      } else {
+        url.searchParams.delete('q');
+      }
+      window.history.replaceState({}, '', url.toString());
+    }
+  };
+
+  const results = useMemo(() => searchPosts(allPosts, query), [allPosts, query]);
+
+  const hasQuery = query.trim().length > 0;
+
+  return (
+    <Layout location={location} title={siteTitle}>
+      <MetaHead title="Cari Artikel" />
+
+      <div className="site-main__inner">
+        <div className="search-header">
+          <h1 className="search-title">Cari Artikel</h1>
+          <p className="search-subtitle">
+            Temukan artikel dari {allPosts.length} tulisan yang tersedia
+          </p>
+        </div>
+
+        <div className="search-form" role="search">
+          <label htmlFor="search-input" className="sr-only">
+            Cari artikel
+          </label>
+          <div className="search-input-wrapper">
+            <SearchIcon />
+            <input
+              ref={inputRef}
+              id="search-input"
+              type="search"
+              className="search-input"
+              placeholder="Ketik kata kunci..."
+              value={query}
+              onChange={handleChange}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        </div>
+
+        {hasQuery && (
+          <div className="section-header">
+            <h2 className="section-title">
+              {results.length > 0
+                ? `Hasil untuk "${query}"`
+                : `Tidak ada hasil untuk "${query}"`}
+            </h2>
+            <span className="section-count" aria-live="polite">
+              {results.length} artikel
+            </span>
+          </div>
+        )}
+
+        {results.length > 0 && (
+          <div className="post-grid" role="list" aria-label="Hasil pencarian">
+            {results.map(node => {
+              const title = node.frontmatter.title || node.fields.slug;
+              return (
+                <article
+                  key={node.fields.slug}
+                  className="post-card"
+                  role="listitem"
+                >
+                  <div className="post-card__pattern" aria-hidden="true">
+                    <AbstractPattern slug={node.fields.slug} />
+                  </div>
+                  <div className="post-card__body">
+                    <div className="post-card__meta">
+                      <time
+                        className="post-card__date"
+                        dateTime={node.frontmatter.dateISO}
+                      >
+                        {node.frontmatter.date}
+                      </time>
+                    </div>
+                    <h3 className="post-card__title">
+                      <Link to={node.fields.slug}>{title}</Link>
+                    </h3>
+                    <p
+                      className="post-card__excerpt"
+                      dangerouslySetInnerHTML={{
+                        __html: node.frontmatter.description || node.excerpt,
+                      }}
+                    />
+                    <Link
+                      to={node.fields.slug}
+                      className="post-card__cta"
+                      aria-label={`Baca artikel: ${title}`}
+                      tabIndex={-1}
+                      aria-hidden="true"
+                    >
+                      Baca artikel
+                      <ArrowRightIcon />
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+
+        {hasQuery && results.length === 0 && (
+          <div className="search-empty">
+            <p>
+              Tidak ada artikel yang cocok dengan{' '}
+              <strong>&ldquo;{query}&rdquo;</strong>.
+            </p>
+            <p>
+              Coba kata kunci lain atau{' '}
+              <Link to="/">lihat semua artikel</Link>.
+            </p>
+          </div>
+        )}
+
+        {!hasQuery && (
+          <div className="search-empty">
+            <SearchIcon size={40} />
+            <p>Ketik kata kunci untuk mulai mencari artikel.</p>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default SearchPage;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1562,6 +1562,152 @@ tbody tr:last-child td {
 }
 
 /* ============================================
+   SITE HEADER NAV
+   ============================================ */
+
+.site-header__nav {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+.site-header__search {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--header-link) !important;
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none !important;
+  transition: background-color var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.site-header__search:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: var(--header-link-hover) !important;
+  border-color: rgba(255, 255, 255, 0.18);
+  text-decoration: none !important;
+}
+
+.site-header__search:visited {
+  color: var(--header-link) !important;
+}
+
+.site-header__search-label {
+  line-height: 1;
+}
+
+/* ============================================
+   SEARCH PAGE
+   ============================================ */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.search-header {
+  margin-bottom: 1.75rem;
+}
+
+.search-title {
+  font-family: var(--font-sans) !important;
+  font-weight: 800 !important;
+  font-size: clamp(1.875rem, 4vw, 2.5rem) !important;
+  color: var(--heading) !important;
+  margin: 0 0 0.5rem !important;
+  letter-spacing: -0.03em;
+}
+
+.search-subtitle {
+  font-family: var(--font-serif);
+  font-size: 0.9375rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.search-form {
+  margin-bottom: 2rem;
+}
+
+.search-input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background-color: var(--bg-secondary);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0.875rem 1.25rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.search-input-wrapper:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.12);
+}
+
+.search-input-wrapper > svg {
+  color: var(--text-subtle);
+  flex-shrink: 0;
+}
+
+.search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: 1.0625rem;
+  color: var(--text);
+  outline: none;
+  min-width: 0;
+}
+
+.search-input::placeholder {
+  color: var(--text-subtle);
+}
+
+.search-input::-webkit-search-decoration,
+.search-input::-webkit-search-cancel-button,
+.search-input::-webkit-search-results-button,
+.search-input::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+
+.search-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: center;
+  padding: 4rem 1.5rem;
+  color: var(--text-muted);
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.search-empty svg {
+  color: var(--border);
+  margin-bottom: 0.5rem;
+}
+
+.search-empty p {
+  margin: 0;
+}
+
+/* ============================================
    PRINT
    ============================================ */
 


### PR DESCRIPTION
- New /search page using useStaticQuery to load all posts at build time
- Instant filtering by title, description, and excerpt (no external deps)
- Multi-word search: all terms must appear somewhere in the post
- URL param sync (?q=...) so search results are bookmarkable/shareable
- Results use existing post-card grid layout and AbstractPattern banners
- Empty state for no-query and no-results conditions
- Search button (icon + label) added to sticky header in Layout
- CSS added for search input, header nav, and sr-only utility

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018btdF8LsdKXV5PMLf4URcT